### PR TITLE
fixed the function setColorTemperature

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ class GoveeLED {
 		    "device": this.mac,
 		    "model": this.model,
 		    "cmd": {
-		        "name": "temperature",
+		        "name": "colorTem",
 		        "value": temperatureLevel
 		    }
 		};


### PR DESCRIPTION
In the function “setColorTemperature” the api cmd was “temperature” and should have been “colorTem”